### PR TITLE
Add initial simple prompt examples for IPD

### DIFF
--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,0 +1,34 @@
+# Prompts for the Iterated Prisoner's Dilemma
+
+Templated prompts use Jinja2. An example:
+
+```python
+from jinja2 import Template
+
+# Define the path to the file
+file_path = "/prompts/simple_ipd_template.txt"
+
+# Read the content of the file into a string
+with open(file_path, 'r') as f:
+    prompt_template = f.read()
+
+# Create a jinja2 template from the string
+template = Template(prompt_template)
+
+# Render the template with specific values for payoffs, history, and examples
+rendered_prompt = template.render(
+    cooperate_cooperate=3,
+    defect_defect=1,
+    cooperate_defect=0,
+    defect_cooperate=5,
+    current_history=[],
+    examples=[
+        {"history": "[(C, C), (C, D)]", "response": "D"},
+        {"history": "[]", "response": "C"}
+    ]
+)
+
+print(rendered_prompt)
+```
+
+The user can change the payoffs of the game, set the current state of the game via the history, or potentially change model behavior by adjusting the examples of gameplay given (e.g, one could pass examples of Tit-for-Tat play vs. grim trigger).

--- a/prompts/explanation_ipd_prompt.txt
+++ b/prompts/explanation_ipd_prompt.txt
@@ -1,0 +1,35 @@
+You are a player in the Axelrod library playing the iterated prisoner's dilemma for an unknown number of rounds.
+
+At each round you will choose C to cooperate or D to defect.
+
+Your payoff in each round depends on your choice of action (C or D) and that of your opponent.
+
+- If you choose C and they choose C, you each get a payoff of 3 for that round.
+
+- If you choose C and they choose D, you get 0 and they get 5.
+
+- If you choose D and they choose C, you get 5 and they get 0.
+
+- If you both choose D, you each get 1 point.
+
+Your goal is to maximize your score over all rounds, but you don't know how many rounds will be played.
+
+At each round you will see the history of actions in the game as a list of tuples in the order of (your move, their move).
+
+Think through your reasoning step by step and then return only either C or D. Now here is the current history. Return one of {C, D}
+
+<examples>
+
+My reasoning is: (insert reasoning here)
+
+Therefore my move is: C
+
+My reasoning is: (insert reasoning here)
+
+Therefore my move is: D
+
+</examples>
+
+History: {{ current_history }}
+
+You:

--- a/prompts/simple_ipd_prompt.txt
+++ b/prompts/simple_ipd_prompt.txt
@@ -1,0 +1,27 @@
+You are a player in the Axelrod library playing the iterated prisoner's dilemma for an unknown number of rounds.
+At each round you will choose C to cooperate or D to defect.
+
+Your payoff in each round depends on your choice of action (C or D) and that of your opponent.
+- If you choose C and they choose C, you each get a payoff of 3 for that round. 
+- If you choose C and they choose D, you get 0 and they get 5.
+- If you choose D and they choose C, you get 5 and they get 0.
+- If you both choose D, you each get 1 point.
+
+Your goal is to maximize your score over all rounds, but you don't know how many rounds will be played.
+
+At each round you will see the history of actions in the game as a list of tuples in the order of (your move, their move).
+
+<examples>
+
+History: [(C, C), (C, D)]
+You: D
+
+History: []
+You: C
+
+</examples>
+
+Only ever return the letters C or D. Do not write anything else -- just one letter. Now here is the current history. Return one of {C, D}
+
+History: []
+You:

--- a/prompts/simple_ipd_template.txt
+++ b/prompts/simple_ipd_template.txt
@@ -1,0 +1,28 @@
+You are a player in the Axelrod library playing the iterated prisoner's dilemma for an unknown number of rounds.
+At each round you will choose C to cooperate or D to defect.
+
+Your payoff in each round depends on your choice of action (C or D) and that of your opponent.
+- If you choose C and they choose C, you each get a payoff of {{ cooperate_cooperate }} for that round. 
+- If you choose C and they choose D, you get {{ cooperate_defect }} and they get {{ defect_cooperate }}.
+- If you choose D and they choose C, you get {{ defect_cooperate }} and they get {{ cooperate_defect }}.
+- If you both choose D, you each get {{ defect_defect }} point.
+
+Your goal is to maximize your score over all rounds, but you don't know how many rounds will be played.
+
+At each round you will see the history of actions in the game as a list of tuples in the order of (your move, their move).
+
+{% if examples %}
+<examples>
+{% for example in examples %}
+
+History: {{ example.history }}
+You: {{ example.response }}
+
+{% endfor %}
+</examples>
+{% endif %}
+
+Only ever return the letters C or D. Do not write anything else -- just one letter. Now here is the current history. Return one of {C, D}
+
+History: {{ current_history }}
+You:


### PR DESCRIPTION
Contains:
- A template for a "simple" prompt that tends to force a model to immediately just return either C or D given some gameplay history.
- A rendered example of the former with the history set to the beginning of the game (i.e, the empty list).
- A prompt that elicits some "reasoning" from the model prior to selecting its move. This "chain-of-thought" style prompt could potentially result in better performance and may be of interest for explanations / "theory of mind."

Future commits may want to make these prompts more modular by parameterizing more pieces (e.g, the preambles, instructions, etc).